### PR TITLE
Match Python depth pipeline in Android app

### DIFF
--- a/app/src/main/java/com/depthpro/android/DepthMapRenderer.java
+++ b/app/src/main/java/com/depthpro/android/DepthMapRenderer.java
@@ -38,7 +38,7 @@ public class DepthMapRenderer {
             for (int x = 0; x < targetWidth; x++) {
                 // Exact Python calculation: (depth * 255.0).astype(np.uint8)
                 double depthValue = depthDouble[y][x];
-                int grayValue = (int) Math.round(Math.max(0.0, Math.min(255.0, depthValue * 255.0)));
+                int grayValue = (int) Math.max(0.0, Math.min(255.0, depthValue * 255.0));
 
                 // Create grayscale pixel (mode="L" equivalent)
                 pixels[y * targetWidth + x] = Color.rgb(grayValue, grayValue, grayValue);


### PR DESCRIPTION
## Summary
- Apply bilateral smoothing and Python-style truncation for chromostereopsis effect
- Normalize input with mean/std and center-crop resize to mirror Hugging Face preprocessing
- Render depth maps with exact uint8 truncation

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891a92b7560832bad25991620dd607e