### PR TITLE
Clamp gamma corrected grayscale values

### DIFF
--- a/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
+++ b/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
@@ -202,7 +202,8 @@ public class ChromostereopsisProcessor {
         double gammaValue = 0.1 + (gammaPercent / 100.0) * 2.9;
 
         for (int i = 0; i < gray.length; i++) {
-            gray[i] = Math.pow(gray[i], gammaValue);
+            double value = Math.pow(gray[i], gammaValue);
+            gray[i] = Math.max(0.0, Math.min(1.0, value));
         }
     }
 


### PR DESCRIPTION
## Summary
- Clamp gamma-corrected grayscale values to [0, 1] in ChromostereopsisProcessor

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b18092c0832b86d8ba174dc78cc1