### PR TITLE
Raise minimum depth scale for chromostereopsis effect

### DIFF
--- a/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
+++ b/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
@@ -211,7 +211,7 @@ public class ChromostereopsisProcessor {
 
         // Exact Python parameter mapping
         double thresholdNorm = params.threshold / 100.0;
-        double steepness = Math.max(params.depthScale, 1e-10); // Avoid division by zero
+        double steepness = Math.max(params.depthScale, 1e-3); // Avoid division by zero
         double featherNorm = params.feather / 100.0;
         double steepnessAdjusted = steepness / (featherNorm * 10.0 + 1.0);
 


### PR DESCRIPTION
## Summary
- prevent divide-by-zero in chromostereopsis effect by clamping depth scale to `1e-3`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b1814070832ba29d8a3e25c5cea3