### PR TITLE
Ensure parity with Python Chromostereopsis pipeline

### DIFF
--- a/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
+++ b/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
@@ -178,8 +178,10 @@ public class ChromostereopsisProcessor {
             double g = (double) ((pixel >> 8) & 0xFF);
             double b = (double) (pixel & 0xFF);
 
-            // Exact PIL luminance formula (ITU-R BT.601)
-            gray[i] = 0.299 * r + 0.587 * g + 0.114 * b;
+            // Exact PIL luminance formula (ITU-R BT.601) with rounding
+            // Pillow rounds to nearest integer when converting to "L"
+            double value = 0.299 * r + 0.587 * g + 0.114 * b;
+            gray[i] = Math.floor(value + 0.5); // match Pillow rounding
         }
 
         return gray;

--- a/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
+++ b/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
@@ -243,10 +243,10 @@ public class DepthAnythingV2Processor {
                 int g = (pixel >> 8) & 0xFF;
                 int b = pixel & 0xFF;
 
-                // Normalize using mean/std from Hugging Face
-                preprocessedImage[y][x][0] = ((r / 255.0f) - 0.45f) / 0.225f; // R
-                preprocessedImage[y][x][1] = ((g / 255.0f) - 0.45f) / 0.225f; // G
-                preprocessedImage[y][x][2] = ((b / 255.0f) - 0.45f) / 0.225f; // B
+                // Normalize using mean/std from Hugging Face preprocessor config
+                preprocessedImage[y][x][0] = ((r / 255.0f) - 0.485f) / 0.229f; // R
+                preprocessedImage[y][x][1] = ((g / 255.0f) - 0.456f) / 0.224f; // G
+                preprocessedImage[y][x][2] = ((b / 255.0f) - 0.406f) / 0.225f; // B
             }
         }
 


### PR DESCRIPTION
## Summary
- Match Hugging Face preprocessing constants for Depth Anything V2 inference
- Round grayscale conversion exactly like Pillow for pixel-identical chromostereopsis results

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b76ea5d8832ba34062d045941009