### PR TITLE
Store scaling info and align depth map

### DIFF
--- a/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
+++ b/app/src/main/java/com/depthpro/android/ChromostereopsisProcessor.java
@@ -36,12 +36,11 @@ public class ChromostereopsisProcessor {
         int originalWidth = original.getWidth();
         int originalHeight = original.getHeight();
 
-        // Resize depth map using exact Python method
+        // Depth map is already aligned with original dimensions
         double[][] depthMapDouble = convertToDouble(depthMap);
-        double[][] resizedDepth = resizeDepthMapPythonExact(depthMapDouble, originalWidth, originalHeight);
 
         // Apply smoothing exactly like Python bilateral filter
-        double[][] smoothedDepth = applyPythonSmoothing(resizedDepth, params.smoothing);
+        double[][] smoothedDepth = applyPythonSmoothing(depthMapDouble, params.smoothing);
 
         // Convert original to grayscale exactly like Python PIL
         double[] grayDouble = convertToGrayscalePythonExact(original);

--- a/app/src/test/java/com/depthpro/android/ChromostereopsisProcessorTest.java
+++ b/app/src/test/java/com/depthpro/android/ChromostereopsisProcessorTest.java
@@ -31,8 +31,8 @@ public class ChromostereopsisProcessorTest {
         Bitmap original = Bitmap.createBitmap(3, 4, Bitmap.Config.ARGB_8888);
         original.eraseColor(Color.WHITE);
 
-        float[][] depth = new float[8][5];
-        depth[7][4] = 1f; // bottom-right depth
+        float[][] depth = new float[4][3];
+        depth[3][2] = 1f; // bottom-right depth
 
         ChromostereopsisProcessor processor = new ChromostereopsisProcessor();
         Bitmap result = processor.applyEffect(original, depth, defaultParams());
@@ -48,11 +48,11 @@ public class ChromostereopsisProcessorTest {
     }
 
     @Test
-    public void applyEffectHandlesSmallDepthMap() {
+    public void applyEffectHandlesAlignedDepthMap() {
         Bitmap original = Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888);
         original.eraseColor(Color.WHITE);
 
-        float[][] depth = new float[1][1]; // minimal depth map
+        float[][] depth = new float[10][10];
 
         ChromostereopsisProcessor processor = new ChromostereopsisProcessor();
         Bitmap result = processor.applyEffect(original, depth, defaultParams());


### PR DESCRIPTION
## Summary
- Track scaling and crop info during preprocessing and reconstruct full depth canvas before resizing
- Accept aligned depth maps in Chromostereopsis effect processing
- Update chromostereopsis tests for new depth map alignment behavior

## Testing
- `gradle test` *(fails: SDK packages missing licenses)*

------
https://chatgpt.com/codex/tasks/task_e_6891c2fb76b0832b8509f4fd2400a767