### PR TITLE
Remove unused utility fields from DepthAnythingV2Processor

### DIFF
--- a/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
+++ b/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
@@ -33,8 +33,6 @@ public class DepthAnythingV2Processor {
     private OrtEnvironment ortEnvironment;
     private OrtSession ortSession;
 
-    private final ImageUtils imageUtils;
-    private final TensorUtils tensorUtils;
     private final DepthMapRenderer depthMapRenderer;
 
     // Track preprocessing details for post-processing
@@ -57,8 +55,6 @@ public class DepthAnythingV2Processor {
 
     public DepthAnythingV2Processor(Context context) throws OrtException, IOException {
         this.context = context;
-        this.imageUtils = new ImageUtils();
-        this.tensorUtils = new TensorUtils();
         this.depthMapRenderer = new DepthMapRenderer();
 
         initializeModel();


### PR DESCRIPTION
## Summary
- drop ImageUtils and TensorUtils fields and corresponding constructor instantiations from DepthAnythingV2Processor

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891c9445a38832bab771c7300ba3544