### PR TITLE
Improve model copy progress logging

### DIFF
--- a/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
+++ b/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
@@ -101,14 +101,16 @@ public class DepthAnythingV2Processor {
                 byte[] buffer = new byte[8192];
                 int bytesRead;
                 long totalBytes = 0;
+                long nextLogThreshold = 50L * 1024 * 1024; // 50MB
 
                 while ((bytesRead = inputStream.read(buffer)) != -1) {
                     outputStream.write(buffer, 0, bytesRead);
                     totalBytes += bytesRead;
 
-                    // Log progress every 50MB
-                    if (totalBytes % (50 * 1024 * 1024) == 0) {
+                    // Log progress every 50MB of data copied
+                    if (totalBytes >= nextLogThreshold) {
                         Log.d(TAG, "Copied " + (totalBytes / (1024 * 1024)) + " MB");
+                        nextLogThreshold += 50L * 1024 * 1024;
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Improve model copy progress logging by replacing fragile modulo check with threshold comparison so progress prints every 50MB.

## Testing
- `java TestCopy`
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891cad02130832ba123247afef4fe78