### PR TITLE
Fix unused variable in DepthAnythingV2Processor

### DIFF
--- a/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
+++ b/app/src/main/java/com/depthpro/android/DepthAnythingV2Processor.java
@@ -149,7 +149,6 @@ public class DepthAnythingV2Processor {
         }
 
         // Create input tensor
-        long[] inputShape = {1, CHANNELS, INPUT_HEIGHT, INPUT_WIDTH};
         OnnxTensor inputTensor = OnnxTensor.createTensor(ortEnvironment, tensorData);
 
         // Run inference


### PR DESCRIPTION
## Summary
- remove unused `inputShape` variable in DepthAnythingV2Processor

## Testing
- `gradle assemble` *(fails: SDK packages not installed / licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_6891cad42e5c832bbba4d9a76f5a3de1